### PR TITLE
Update site details from settings

### DIFF
--- a/eosidp/settings/base.py
+++ b/eosidp/settings/base.py
@@ -176,6 +176,8 @@ USE_TZ = True
 # Site ID, required for allauth
 # https://docs.djangoproject.com/en/3.0/ref/contrib/sites/
 SITE_ID = env_int('SITE_ID', 1)
+SITE_DOMAIN = env_str('SITE_DOMAIN', None)
+SITE_NAME = env_str('SITE_NAME', None)
 
 
 # Static files (CSS, JavaScript, Images)

--- a/eosidp/settings/base.py
+++ b/eosidp/settings/base.py
@@ -38,7 +38,6 @@ ALLOWED_HOSTS = env_list('ALLOWED_HOSTS')
 
 # Application definition
 INSTALLED_APPS = [
-    'main.apps.MainConfig',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -54,6 +53,7 @@ INSTALLED_APPS = [
     'health_check',
     'health_check.db',
     'health_check.cache',
+    'main.apps.MainConfig',
 ]
 
 MIDDLEWARE = [

--- a/example.env
+++ b/example.env
@@ -59,9 +59,14 @@
 #LOG_LEVEL=INFO
 #ROOT_LOG_LEVEL=WARNING
 
-# Site ID. This should be 1 unless there are multiple sites registered.
+# Site configuration. SITE_ID should be 1 unless there are multiple
+# sites registered. SITE_DOMAIN and SITE_NAME correspond to the domain
+# and name fields of the Site model, respectively.
 # https://docs.djangoproject.com/en/3.0/ref/settings/#site-id
+# https://docs.djangoproject.com/en/3.0/ref/contrib/sites/#django.contrib.sites.models.Site
 #SITE_ID=1
+#SITE_DOMAIN=eosidp.example.com
+#SITE_NAME=Example Accounts
 
 # Google authentication. GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are
 # then OAuth2 client ID and secret, respectively. Also available from

--- a/main/signals.py
+++ b/main/signals.py
@@ -1,5 +1,6 @@
 from Cryptodome.PublicKey import RSA
 from django.apps import apps as global_apps
+from django.conf import settings
 from django.db import DEFAULT_DB_ALIAS, IntegrityError, router
 from django.db.models.signals import post_migrate
 from django.dispatch import receiver
@@ -32,3 +33,35 @@ def ensure_rsakey(app_config, verbosity=2, interactive=True,
         RSAKey.objects.using(using).create(pk=1, key=key)
     except IntegrityError:
         pass
+
+
+@receiver(post_migrate, sender=global_apps.get_app_config('sites'))
+def setup_site(app_config, verbosity=2, interactive=True,
+               using=DEFAULT_DB_ALIAS, apps=global_apps, **kwargs):
+    """Setup Site details from settings
+
+    Use the SITE_ID, SITE_DOMAIN and SITE_NAME settings to set the Site
+    details for this project. The sites app automatically generates site
+    ID 1, but it just uses example.com as the domain and name. This will
+    update that site or create a new one if a different SITE_ID is
+    specified.
+    """
+    if not all((settings.SITE_ID, settings.SITE_DOMAIN, settings.SITE_NAME)):
+        return
+
+    try:
+        Site = apps.get_model('sites', 'Site')
+    except LookupError:
+        return
+
+    if not router.allow_migrate_model(using, Site):
+        return
+
+    fields = {
+        'domain': settings.SITE_DOMAIN,
+        'name': settings.SITE_NAME,
+    }
+    site, created = Site.objects.using(using).update_or_create(
+        id=settings.SITE_ID, defaults=fields)
+    if verbosity >= 1:
+        print('Created' if created else 'Updated', site.name, 'site')


### PR DESCRIPTION
The default generated Site uses the domain and name example.com, and these show up in a couple places in the HTML. You can always go into the admin console and update this site, but this allows setting the domain and name from settings and environment variables.

https://phabricator.endlessm.com/T30384