### PR TITLE
socialaccount: Include email address in connections

### DIFF
--- a/main/templates/socialaccount/connections.html
+++ b/main/templates/socialaccount/connections.html
@@ -1,5 +1,6 @@
 {% extends "socialaccount/base.html" %}
 
+{% load main %}
 {% load i18n %}
 
 {% block title %}{% trans "Account Connections" %}{% endblock %}
@@ -25,7 +26,7 @@
 <label for="id_account_{{ base_account.id }}">
 <input id="id_account_{{ base_account.id }}" type="radio" name="account" value="{{ base_account.id }}"/>
 <span class="socialaccount_provider {{ base_account.provider }} {{ account.get_brand.id }}">{{account.get_brand.name}}</span>
-{{ account }}
+{% social_account_display base_account %}
 </label>
 </div>
 {% endwith %}

--- a/main/templatetags/main.py
+++ b/main/templatetags/main.py
@@ -1,0 +1,21 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def social_account_display(social_account):
+    """String to display for social account"""
+    # Start with the string from the provider account
+    provider_account = social_account.get_provider_account()
+    display = str(provider_account)
+
+    # Try to add the email address from the social account's extra data
+    # using the provider's method for converting to standard field names
+    provider = social_account.get_provider()
+    common_fields = provider.extract_common_fields(social_account.extra_data)
+    email = common_fields.get('email')
+    if email:
+        display += f' ({email})'
+
+    return display


### PR DESCRIPTION
Add a custom `social_account_display` template tag that includes the
email address from the social account provider if possible. This allows
disambiguating multiple connections from the same provider since the
provider's display name is typically the user's full name and is likely
to be the same on both social accounts.

Closes: #2