### PR TITLE
Add JS to clean Facebook OAuth redirect URL

### DIFF
--- a/main/static/js/eosidp.js
+++ b/main/static/js/eosidp.js
@@ -1,0 +1,19 @@
+// Facebook Login OAuth redirects the user with an ugly #_=_ URL
+// fragment. Strip that off.
+//
+// https://stackoverflow.com/a/18305085
+function stripFacebookOAuthFragment() {
+    if (window.location.hash === "#_=_") {
+        // If the browser supports history.replaceState, strip the whole
+        // fragment. Otherwise just the _=_.
+        if (history.replaceState) {
+            var noFragment = window.location.href.split("#")[0];
+            history.replaceState(null, null, noFragment);
+        } else {
+            window.location.hash = "";
+        }
+    }
+}
+
+// Strip the fragment immediately after loading.
+window.onload = stripFacebookOAuthFragment;

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -75,6 +75,7 @@
             integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI"
             crossorigin="anonymous">
     </script>
+    <script src="{% static 'js/eosidp.js' %}"></script>
     {% block extra_body %}
     {% endblock %}
   </body>


### PR DESCRIPTION
When Facebook's server redirects the client back to the app, it appends
an ugly `#_=_` fragment for unknown reasons. This has been reported and
is unlikely to change as discussed in
https://stackoverflow.com/questions/7131909/. Add a bit of javascript to
strip that ugly fragment off.

I am a JS novice, so I very likely may be doing it wrong.

https://phabricator.endlessm.com/T30906