### PR TITLE
Add Jenkinsfile for building docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,34 @@
+// The primary image tag. For a pull request, the tag will be named
+// pr<number>. Otherwise the branch name will be used.
+def tag = params.ghprbPullId ? 'pr' + params.ghprbPullId : env.GIT_BRANCH
+
+// An extra image tag such as `latest` from a TAG job parameter.
+def extra_tag = params.TAG
+
+// Registry URL and credentials to use for pushing.
+def registry = params.REGISTRY ?: 'https://index.docker.io/v1/'
+def credentials = params.CREDENTIALS ?: 'dockerhub-endlessci'
+
+node {
+    def image
+
+    stage('Build') {
+        checkout scm
+        image = docker.build("endlessm/eos-idp:${tag}")
+    }
+
+    stage('Test') {
+        image.inside {
+            sh './manage.py test --settings eosidp.settings.test'
+        }
+    }
+
+    stage('Publish') {
+        docker.withRegistry(registry, credentials) {
+            image.push()
+            if (extra_tag) {
+                image.push(extra_tag)
+            }
+        }
+    }
+}

--- a/eosidp/settings/test.py
+++ b/eosidp/settings/test.py
@@ -1,0 +1,7 @@
+# Settings to be used during tests. This is not intended to be used at
+# runtime.
+from .base import *  # noqa
+
+# Ensure SECRET_KEY is not empty
+if not SECRET_KEY:
+    SECRET_KEY = 'badsecret'


### PR DESCRIPTION
This will build the image and push it to the endlessm/eos-idp repository
on Docker Hub. The image tag will be `pr<number>` for a pull request or
the git branch name. An additional tag such as `latest` can be provided
via the `TAG` job parameter.