### PR TITLE
settings: Bump Facebook Graph API version to v19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim AS build
+FROM docker.io/python:3.9-slim AS build
 
 RUN apt-get update && \
     apt-get -y install \
@@ -11,9 +11,9 @@ COPY requirements.txt /
 RUN pip install --no-cache-dir --root /dest --no-warn-script-location \
     -r requirements.txt
 
-FROM vault:latest AS vault
+FROM docker.io/hashicorp/vault:latest AS vault
 
-FROM python:3.9-slim
+FROM docker.io/python:3.9-slim
 
 RUN apt-get update && \
     apt-get -y install \

--- a/eosidp/settings/base.py
+++ b/eosidp/settings/base.py
@@ -163,7 +163,7 @@ if FACEBOOK_CLIENT_ID and FACEBOOK_CLIENT_SECRET:
     INSTALLED_APPS.append('allauth.socialaccount.providers.facebook')
     SOCIALACCOUNT_PROVIDERS['facebook'] = {
         'SCOPE': ['public_profile', 'email'],
-        'VERSION': 'v9.0',
+        'VERSION': 'v19.0',
         'APP': {
             'client_id': FACEBOOK_CLIENT_ID,
             'secret': FACEBOOK_CLIENT_SECRET,


### PR DESCRIPTION
Per the Graph API changelog[1], v19.0 is the current version. The only Graph API used directly by allauth is the User Picture API[2], and that does not appear to have changed. The actual login calls are managed by the Facebook JS SDK, which presumably knows how to use the newer Graph API version.

1. https://developers.facebook.com/docs/graph-api/changelog/
2. https://developers.facebook.com/docs/graph-api/reference/user/picture/

https://phabricator.endlessm.com/T35222