### PR TITLE
docker: Update AWS RDS CA bundle URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
         && \
     apt-get clean
 
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem \
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
     /usr/local/share/ca-certificates/rds.crt
 RUN update-ca-certificates
 


### PR DESCRIPTION
We've been installing the RDS CA bundle from
https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem for years. However, the documented[1] URL is
https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem. The former hasn't been updated in years and all the certificates in it are about to expire:

$ curl -sSIL https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem | grep -i ^last-modified: Last-Modified: Tue, 28 Apr 2020 15:18:37 GMT
$ curl -sSIL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem | grep -i ^last-modified: last-modified: Mon, 18 Dec 2023 20:34:46 GMT

This should have no compatibility issues as global-bundle.pem is a superset of rds-combined-ca-bundle.pem including all the soon to be expired CA certificates.

1. https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions

https://phabricator.endlessm.com/T35141