### PR TITLE
settings: Make email addresses optional for social accounts

### DIFF
--- a/eosidp/settings/base.py
+++ b/eosidp/settings/base.py
@@ -135,6 +135,11 @@ ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 ACCOUNT_SIGNUP_FORM_CLASS = 'main.forms.SignupForm'
 ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = True
 
+# For social accounts, emails are optional as the provider is handling
+# authentication of the user.
+SOCIALACCOUNT_EMAIL_REQUIRED = False
+SOCIALACCOUNT_EMAIL_VERIFICATION = 'optional'
+
 
 # Social account provider settings
 SOCIALACCOUNT_PROVIDERS = {}


### PR DESCRIPTION
For normal username/password accounts, it makes sense to require email verification so that you can't claim someone else's address. It's also important for resetting the user's password as that's the only means of authentication.

However, if a user is signing up with a social account provider (Google or Facebook), the provider is supplying the email address and we can assume they've done some diligence that the user owns it. Furthermore, they don't need the email address for password resets since authentication comes from the provider. Allow email addresses to be optional in that case.

https://phabricator.endlessm.com/T35763

I haven't tested this yet, but I'm pretty sure this should take care of the Facebook QA issue.